### PR TITLE
Skip updating skills that are not defined locally

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ install:
   - travis_retry npm install
 
 script:
-  - npm run lint
+  - npm run test

--- a/lib/diffModels.js
+++ b/lib/diffModels.js
@@ -13,17 +13,21 @@ module.exports = {
           .map(function (model) {
             const localSkills = this.serverless.service.custom.alexa.skills;
             const local = localSkills.find(skill => skill.id === model.id);
-            let localModel = null;
-            if (model.locale in local.models) {
-              localModel = local.models[model.locale];
+            let ret;
+            if (!(typeof local === 'undefined')) {
+              let localModel = null;
+              if (model.locale in local.models) {
+                localModel = local.models[model.locale];
+              }
+              ret = {
+                skillId: local.id,
+                locale: model.locale,
+                diff: diff(model.model, localModel),
+              };
             }
-            const ret = {
-              skillId: local.id,
-              locale: model.locale,
-              diff: diff(model.model, localModel),
-            };
             return BbPromise.resolve(ret);
-          });
+          })
+          .then(ret => BbPromise.resolve(ret.filter(v => !(typeof v === 'undefined'))));
       });
   },
 };

--- a/lib/diffSkills.js
+++ b/lib/diffSkills.js
@@ -10,11 +10,15 @@ module.exports = {
       .map(function (remote) {
         const localSkills = this.serverless.service.custom.alexa.skills;
         const local = localSkills.find(skill => skill.id === remote.skillId);
-        const ret = {
-          skillId: local.id,
-          diff: diff(remote.skillManifest, local.skillManifest),
-        };
+        let ret;
+        if (!(typeof local === 'undefined')) {
+          ret = {
+            skillId: local.id,
+            diff: diff(remote.skillManifest, local.skillManifest),
+          };
+        }
         return BbPromise.resolve(ret);
-      });
+      })
+      .then(ret => BbPromise.resolve(ret.filter(v => !(typeof v === 'undefined'))));
   },
 };

--- a/test/diffModels.js
+++ b/test/diffModels.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const expect = require('chai').expect;
+const diffModels = require('./../lib/diffModels');
+
+describe('diffModels()', () => {
+
+  beforeEach(() => {
+    diffModels.serverless = { service: { custom: { alexa: { skills: [] }}}};
+  });
+
+  it('should return diff if it has the same ID', () => {
+    let localSkills = [{
+      id: 'foo',
+      models: {
+        'ja-JP': { foo: 'bar' }
+      }
+    }]
+    let remoteSkills = [[{
+      id: 'foo',
+      local: 'ja-JP',
+      model: { foo: 'buz' }
+    }]]
+
+    diffModels.serverless.service.custom.alexa.skills = localSkills;
+    diffModels.diffModels(remoteSkills).then((ret) => {
+      expect(ret.pop().length).to.equal(1);
+    });
+  });
+
+  it('should not return diff if it has not the same ID', () => {
+    let localSkills = [{
+      id: 'foo',
+      models: {
+        'ja-JP': { foo: 'bar' }
+      }
+    }]
+    let remoteSkills = [[{
+      id: 'bar',
+      local: 'ja-JP',
+      model: { foo: 'buz' }
+    }]]
+
+    diffModels.serverless.service.custom.alexa.skills = localSkills;
+    diffModels.diffModels(remoteSkills).then((ret) => {
+      expect(ret.pop().length).to.equal(0);
+    });
+  });
+});

--- a/test/diffSkills.js
+++ b/test/diffSkills.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const expect = require('chai').expect;
+const diffSkills = require('./../lib/diffSkills');
+
+describe('diffSkills()', () => {
+
+  beforeEach(() => {
+    diffSkills.serverless = { service: { custom: { alexa: { skills: [] }}}};
+  });
+
+  it('should return diff if it has the same ID', () => {
+    let localSkills = [{
+      id: 'foo',
+      skillManifest: { foo: 'bar' }
+    }]
+    let remoteSkills = [{
+      skillId: 'foo',
+      skillManifest: { foo: 'buz' }
+    }]
+
+    diffSkills.serverless.service.custom.alexa.skills = localSkills;
+    diffSkills.diffSkills(remoteSkills).then((ret) => {
+      expect(ret.length).to.equal(1);
+    });
+  });
+
+  it('should not return diff if it has not the same ID', () => {
+    let localSkills = [{
+      id: 'foo',
+      skillManifest: { foo: 'bar' }
+    }]
+    let remoteSkills = [{
+      skillId: 'bar',
+      skillManifest: { foo: 'buz' }
+    }]
+
+    diffSkills.serverless.service.custom.alexa.skills = localSkills;
+    diffSkills.diffSkills(remoteSkills).then((ret) => {
+      expect(ret.length).to.equal(0);
+    });
+  });
+});


### PR DESCRIPTION
An error occurs if there are skills that are not defined locally.

```
`TypeError: Cannot read property 'id' of undefined
```