### PR TITLE
Use default security profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,6 @@ npm install serverless-alexa-skills
 
 # Setup
 
-#### First, you need to create a ["Security Profile"](https://developer.amazon.com/docs/login-with-amazon/security-profile.html) and configure ["Login with Amazon"](https://developer.amazon.com/ja/docs/login-with-amazon/web-docs.html).
-
 #### Next, Check your Client ID, Client Secret and [Vendor ID](https://developer.amazon.com/mycid.html) at [Amazon developer console](https://developer.amazon.com/home.html).
 
 See: [the step-by-step guide](https://github.com/marcy-terui/serverless-alexa-skills/wiki/How-to-get-your-%22Login-with-Amazon%22-credentials)
@@ -47,8 +45,6 @@ plugins:
 custom:
   alexa:
     vendorId: ${env:YOUR_AMAZON_VENDOR_ID}
-    clientId: ${env:YOUR_AMAZON_CLIENT_ID}
-    clientSecret: ${env:YOUR_AMAZON_CLIENT_SECRET}
     skills:
       - id: ${env:YOUR_ALEXA_SKILL_ID}
         skillManifest:

--- a/lib/initialize.js
+++ b/lib/initialize.js
@@ -6,12 +6,12 @@ const homedir = require('os').homedir();
 
 module.exports = {
   initialize() {
-    this.localServerPort = this.serverless.service.custom.alexa.localServerPort || 3000;
+    this.localServerPort = this.serverless.service.custom.alexa.localServerPort || 9090;
     this.tokenFilePath = path.join(homedir, '.serverless', this.TOKEN_FILE_NAME);
     this.oauth2 = so2.create({
       client: {
-        id: this.serverless.service.custom.alexa.clientId,
-        secret: this.serverless.service.custom.alexa.clientSecret,
+        id: this.serverless.service.custom.alexa.clientId || 'amzn1.application-oa2-client.aad322b5faab44b980c8f87f94fbac56',
+        secret: this.serverless.service.custom.alexa.clientSecret || '1642d8869b829dda3311d6c6539f3ead55192e3fc767b9071c888e60ef151cf9',
       },
       auth: {
         authorizeHost: 'https://www.amazon.com',

--- a/lib/openAuthorizationUri.js
+++ b/lib/openAuthorizationUri.js
@@ -6,7 +6,7 @@ const opn = require('opn');
 module.exports = {
   openAuthorizationUri() {
     const authorizationUri = this.oauth2.authorizationCode.authorizeURL({
-      redirect_uri: `http://localhost:${this.localServerPort}`,
+      redirect_uri: `http://127.0.0.1:${this.localServerPort}/cb`,
       scope: 'alexa::ask:skills:readwrite alexa::ask:models:readwrite alexa::ask:skills:test',
       state: crypto.randomBytes(32).toString('hex'),
     });

--- a/lib/requestHandler.js
+++ b/lib/requestHandler.js
@@ -9,7 +9,7 @@ module.exports = function (req, res) {
   if ('code' in query) {
     this.oauth2.authorizationCode.getToken({
       code: query.code,
-      redirect_uri: `http://localhost:${this.localServerPort}`,
+      redirect_uri: `http://127.0.0.1:${this.localServerPort}/cb`,
     })
       .then((result) => {
         fs.outputJsonSync(this.tokenFilePath, this.oauth2.accessToken.create(result));


### PR DESCRIPTION
Simplify plugin setup by offering the default profile instead of requiring the user to creating a custom Amazon Security Profile.

This is the same security profile as used by the official CLI, therefore, we can just align our URLs to match with theirs:
- Use `http://127.0.0.1/cb` instead of `http://localhost`.