### PR TITLE
Make the authorization works on not-localhost environments

### DIFF
--- a/lib/createHttpServer.js
+++ b/lib/createHttpServer.js
@@ -11,7 +11,7 @@ module.exports = {
     server.oauth2 = this.oauth2;
     server.localServerPort = this.localServerPort;
     server.on('request', requestHandler);
-    server.listen(this.localServerPort, '127.0.0.1');
+    server.listen(this.localServerPort);
     return BbPromise.resolve();
   },
 };

--- a/lib/openAuthorizationUri.js
+++ b/lib/openAuthorizationUri.js
@@ -5,11 +5,21 @@ const opn = require('opn');
 
 module.exports = {
   openAuthorizationUri() {
+    const options = this.options;
     const authorizationUri = this.oauth2.authorizationCode.authorizeURL({
       redirect_uri: `http://127.0.0.1:${this.localServerPort}/cb`,
       scope: 'alexa::ask:skills:readwrite alexa::ask:models:readwrite alexa::ask:skills:test',
       state: crypto.randomBytes(32).toString('hex'),
     });
-    return opn(authorizationUri);
-  },
+    if (
+      typeof options["no-localhost"] === 'undefined' ||
+      !options["no-localhost"]
+    ) {
+      return opn(authorizationUri);
+    }
+    else {
+      console.log("To authenticate with AWS just follow this link:", authorizationUri);
+      return Promise.resolve();
+    }
+  }
 };


### PR DESCRIPTION
With this set of changes and it is possible to authorise alexa also in a not-localhost environment, like Docker or a remote server which is not capable to open a system browser with opn. 