### PR TITLE
Call the Alexa API in serial to avoid throttling

### DIFF
--- a/lib/AlexaApi.js
+++ b/lib/AlexaApi.js
@@ -40,11 +40,13 @@ class AlexaApi {
       url = `${url}?${qs.stringify(params)}`;
     }
 
-    return this.getHeaders().then(headers => rp({
-      url,
-      method: 'GET',
-      headers,
-    }));
+    return this.getHeaders()
+      .delay(200)
+      .then(headers => rp({
+        url,
+        method: 'GET',
+        headers,
+      }));
   }
   _jsonRequest(url, method, params) {
     return this.getHeaders().then(headers => ({
@@ -96,7 +98,7 @@ class AlexaApi {
       .then(function () {
         return BbPromise.resolve(this._getSkills(vendorId));
       })
-      .map(function (skill) {
+      .mapSeries(function (skill) {
         return this.get(skill._links.self.href).then((body) => {
           const ret = JSON.parse(body);
           ret.skillId = skill.skillId;
@@ -110,14 +112,14 @@ class AlexaApi {
       .then(function () {
         return BbPromise.resolve(this.getSkills(vendorId));
       })
-      .map(function (skill) {
+      .mapSeries(function (skill) {
         const skillLocales = skill.manifest.publishingInformation.locales;
         const locales = Object.keys(skillLocales).map(function (locale) {
           return { id: this.skillId, locale };
         }, skill);
         return BbPromise.bind(this)
           .then(() => BbPromise.resolve(locales))
-          .map(function (locale) {
+          .mapSeries(function (locale) {
             return this.get(`/skills/${locale.id}/stages/development/interactionModel/locales/${locale.locale}`).then(body => BbPromise.resolve({
               id: locale.id,
               locale: locale.locale,

--- a/lib/updateModels.js
+++ b/lib/updateModels.js
@@ -8,10 +8,10 @@ module.exports = {
     const alexaApi = new AlexaApi(this.getToken());
     return BbPromise.bind(this)
       .then(() => BbPromise.resolve(diffs))
-      .map(function (diff) {
+      .mapSeries(function (diff) {
         return BbPromise.bind(this)
           .then(() => BbPromise.resolve(diff))
-          .map(function (model) {
+          .mapSeries(function (model) {
             const localSkills = this.serverless.service.custom.alexa.skills;
             const local = localSkills.find(skill => skill.id === model.skillId);
             if (

--- a/lib/updateSkills.js
+++ b/lib/updateSkills.js
@@ -8,7 +8,7 @@ module.exports = {
     const alexaApi = new AlexaApi(this.getToken());
     return BbPromise.bind(this)
       .then(() => BbPromise.resolve(diffs))
-      .map(function (diff) {
+      .mapSeries(function (diff) {
         if (diff.diff != null) {
           const localSkills = this.serverless.service.custom.alexa.skills;
           const local = localSkills.find(skill => skill.id === diff.skillId);


### PR DESCRIPTION
When you are supporting a larger number of skills, models, or locales, the number of Alexa API calls increases. The requests are often throttled because we are sending too many at once. If we send the requests in serial, we can avoid getting throttled.

Yes, it is slightly slower, but at least it doesn't fail. 

I tried this change on a test skill that supports all 13 locales that Amazon supports. Without the delay, the API calls still occasionally fail. 200ms was the sweet spot where it doesn't fail, but it doesn't take too long either. It's a little bit of a guessing game as I can't find the actual request limit in the Alexa documentation.

This should resolve issue #26.