### PR TITLE
check update status to report errors on `build` and `update`

### DIFF
--- a/lib/AlexaApi.js
+++ b/lib/AlexaApi.js
@@ -53,6 +53,7 @@ class AlexaApi {
       headers,
       json: true,
       body: params,
+      resolveWithFullResponse: true
     }));
   }
   post(path, params) {
@@ -136,6 +137,52 @@ class AlexaApi {
           });
       });
   }
+  getUpdateStatus(url) {
+    return BbPromise
+      .delay(1000)
+      .then(() => this.get(url))
+      .then(resp => JSON.parse(resp));
+  }
+  checkModelUpdateStatus(url, locale) {
+    return this.getUpdateStatus(url)
+      .then((resp) => {
+        if (resp.interactionModel) {
+          const status = resp.interactionModel[locale].lastUpdateRequest.status;
+
+          if (status === 'IN_PROGRESS') {
+            return this.checkModelUpdateStatus(url, locale);
+          }
+
+          if (status === 'FAILED') {
+            const errors = resp.interactionModel.lastUpdateRequest.errors.map((error) => {
+              return error.message;
+            });
+
+            throw new Error(errors.join('\n'));
+          }
+        }
+      });
+  }
+  checkSkillUpdateStatus(url) {
+    return this.getUpdateStatus(url)
+      .then((resp) => {
+        if (resp.manifest) {
+          const status = resp.manifest.lastUpdateRequest.status;
+
+          if (status === 'IN_PROGRESS') {
+            return this.checkSkillUpdateStatus(url);
+          }
+
+          if (status === 'FAILED') {
+            const errors = resp.manifest.lastUpdateRequest.errors.map((error) => {
+              return error.message;
+            });
+
+            throw new Error(errors.join('\n'));
+          }
+        }
+    });
+  }
   createSkill(vendorId, name, locale, type) {
     return this.post('/skills', {
       vendorId,
@@ -151,18 +198,21 @@ class AlexaApi {
           [type]: {},
         },
       },
-    }).then(body => BbPromise.resolve(body.skillId));
+    })
+    .tap(resp => this.checkSkillUpdateStatus(resp.headers.location))
+    .then(resp => BbPromise.resolve(resp.body.skillId));
   }
   updateSkill(skillId, manifest) {
     return this.put(`/skills/${skillId}/stages/development/manifest`, {
       manifest,
-    }).then(() => BbPromise.resolve(skillId));
+    })
+    .tap(resp => this.checkSkillUpdateStatus(resp.headers.location))
+    .then(() => BbPromise.resolve(skillId));
   }
   updateModel(skillId, locale, model) {
-    return this.put(
-      `/skills/${skillId}/stages/development/interactionModel/locales/${locale}`,
-      model
-    ).then(() => BbPromise.resolve({ id: skillId, locale }));
+    return this.put(`/skills/${skillId}/stages/development/interactionModel/locales/${locale}`, model)
+      .tap(resp => this.checkModelUpdateStatus(resp.headers.location, locale))
+      .then(() => BbPromise.resolve({ id: skillId, locale }));
   }
   deleteSkill(id) {
     return this.delete(`/skills/${id}`);


### PR DESCRIPTION
Currently, the `build` and `update` commands assume success. 

Since these commands are asynchronous, we need to make successive calls to check on the status of the operation. The [SMAPI docs](https://developer.amazon.com/docs/smapi/skill-operations.html#response-2) mention that the response for these requests contain a `Location` header which is a relative URL that can be used to track the status. This PR makes use of that `Location` URL to report any actual errors that have happened.