### PR TITLE
Fix deprecation warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,16 +88,19 @@ class AlexaSkills {
                 usage: 'Name of the skill',
                 shortcut: 'n',
                 required: true,
+                type: 'string',
               },
               locale: {
                 usage: 'First locale of the skill (e.g. "ja-JP", "en-US")',
                 shortcut: 'l',
                 required: true,
+                type: 'string',
               },
               type: {
                 usage: 'Type of the skill (e.g. "custom", "smartHome", "video")',
                 shortcut: 't',
                 required: true,
+                type: 'string',
               },
             },
           },
@@ -111,6 +114,7 @@ class AlexaSkills {
                 usage: 'Skill ID',
                 shortcut: 'i',
                 required: true,
+                type: 'string',
               },
             },
           },
@@ -123,6 +127,7 @@ class AlexaSkills {
               dryRun: {
                 usage: 'Dry run (Only output the diff)',
                 shortcut: 'd',
+                type: 'boolean',
               },
             },
           },
@@ -135,6 +140,7 @@ class AlexaSkills {
               dryRun: {
                 usage: 'Dry run (Only output the diff)',
                 shortcut: 'd',
+                type: 'boolean',
               },
             },
           },


### PR DESCRIPTION
This pull request fixes the following deprecation warning:
```
CLI options definitions were upgraded with "type" property (which could be one of "string", "boolean", "multiple"). Below listed plugins do not predefine type for introduced options:
 - AlexaSkills for "name", "locale", "type", "id", "dryRun"
```